### PR TITLE
Copy all SSH host keys to avoid changing the fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The `emergency` script (found in the repository root) will SSH over and execute 
 The `kexec` script (found in `kexec.nix`) will do the following:
 
 1. Prepare a second initrd
-2. Put your SSH host key (`ed25519` only) into the initrd
+2. Put your SSH host keys into the initrd
 3. Put all of your SSH user keys into the initrd
 4. Fetch all your IP addresses and routes and put them into the initrd
 5. Pack the second initrd and append it to the default NixOS initrd from the emergency image

--- a/kexec.nix
+++ b/kexec.nix
@@ -16,8 +16,9 @@
       cd $(mktemp -d)
       mkdir initrd
       pushd initrd
-      cat /etc/ssh/ssh_host_ed25519_key > ed25519_host_key
-      cat /etc/ssh/ssh_host_ed25519_key.pub > ed25519_host_key.pub
+      for i in /etc/ssh/ssh_host_*; do
+        cat "$i" > "$(basename "$i")"
+      done        
       ${./ip-to-ip} > ip-script
       ${./ssh-keys} > ssh-keys 2>&1
       chmod 755 ip-script
@@ -33,8 +34,9 @@
   boot.initrd.postMountCommands = ''
     mkdir -p /mnt-root/etc/ssh /mnt-root/root/.ssh
     umask 077
-    cat /ed25519_host_key > /mnt-root/etc/ssh/ssh_host_ed25519_key
-    cat /ed25519_host_key.pub > /mnt-root/etc/ssh/ssh_host_ed25519_key.pub
+    for i in /ssh_host_*; do
+      cat "$i" > /mnt-root/etc/ssh/"$i"
+    done
     cat /ssh-keys > /mnt-root/root/.ssh/authorized_keys
     cat /ip-script > /mnt-root/kexec-ips
   '';


### PR DESCRIPTION
I used emergency-kexec to kexec a Debian 10 machine, and `ssh` complained about the fingerprint changing. I changed it to copy all the SSH host keys and confirmed that the fingerprint was unchanged.